### PR TITLE
Package as Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,85 @@
+{
+  "nodes": {
+    "GUSbase": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1706239125,
+        "narHash": "sha256-nRCiKzzF+azIgu1QmKFR47sJioj7IxY2+fL7JFcXLHI=",
+        "owner": "tesujimath",
+        "repo": "GUSbase",
+        "rev": "3db7a46cc30b88e7ac227cb37865d92e322fd75e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tesujimath",
+        "ref": "nix-flake",
+        "repo": "GUSbase",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1706234771,
+        "narHash": "sha256-mccsE0408Rbad2Alz4tzyxEqjyWhcBC6PWJY3GXspTQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6ce373f8ebee695e09af872200541fa61cdc6466",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "GUSbase": "GUSbase",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -10,16 +10,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1706239125,
+        "lastModified": 1708559792,
         "narHash": "sha256-nRCiKzzF+azIgu1QmKFR47sJioj7IxY2+fL7JFcXLHI=",
-        "owner": "tesujimath",
+        "owner": "tpbilton",
         "repo": "GUSbase",
-        "rev": "3db7a46cc30b88e7ac227cb37865d92e322fd75e",
+        "rev": "5cbdaf08b823acd63c8c2c110841fe9831d389b9",
         "type": "github"
       },
       "original": {
-        "owner": "tesujimath",
-        "ref": "nix-flake",
+        "owner": "tpbilton",
         "repo": "GUSbase",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
     GUSbase = {
-      url = github:tesujimath/GUSbase/nix-flake;
+      url = github:tpbilton/GUSbase;
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "GUSMap";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+    GUSbase = {
+      url = github:tesujimath/GUSbase/nix-flake;
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, GUSbase }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+          };
+
+          flakePkgs = {
+            GUSbase = GUSbase.packages.${system}.default;
+          };
+
+          GUSMap = with pkgs;
+            rPackages.buildRPackage {
+              name = "GUSMap";
+              src = ./.;
+              propagatedBuildInputs = with rPackages;
+                [ R6 smacof princurve Rdpack data_table parallel doParallel iterators foreach Rcpp plotly flakePkgs.GUSbase ];
+            };
+
+          R-with-GUSMap = with pkgs;
+            rWrapper.override {
+              packages = with rPackages;
+                [ GUSMap ];
+            };
+        in
+          with pkgs;
+          {
+            devShells.default = mkShell {
+              buildInputs = [ R-with-GUSMap ];
+              shellHook = ''
+            mkdir -p "$(pwd)/_libs"
+            export R_LIBS_USER="$(pwd)/_libs"
+          '';
+            };
+
+            packages.default = GUSMap;
+          });
+}


### PR DESCRIPTION
This is a draft, until the PR is merged in `GUSbase`.

Add Nix flake to enable local development and also downstream consumption of this R package as a Nix flake.

For the former, simply run `nix develop` in the repo root directory, which makes `R` available with `GUSMap` and its dependencies installed.