### PR TITLE
Fix nixpkgs URL to use nixpkgs-unstable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "GUSMap";
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     GUSbase = {
       url = github:tpbilton/GUSbase;


### PR DESCRIPTION
Best not to use master branch, nixpkgs-unstable has a quality gate of the test suite which master branch does not.